### PR TITLE
URL Cleanup

### DIFF
--- a/org.springframework.build.aws.ant/ivy.xml
+++ b/org.springframework.build.aws.ant/ivy.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://ivyrep.jayasoft.org/ivy-doc.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://ivyrep.jayasoft.org/ivy-doc.xsl"?>
 <ivy-module
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="http://incubator.apache.org/ivy/schemas/ivy.xsd"
+		xsi:noNamespaceSchemaLocation="https://incubator.apache.org/ivy/schemas/ivy.xsd"
 		version="1.3">
 
 	<info organisation="org.springframework.build" module="${ant.project.name}">

--- a/spring-build/common/common.xml
+++ b/spring-build/common/common.xml
@@ -227,7 +227,7 @@
 			<javadoc.links sourcepath="@{input.dir}" destdir="@{output.dir}" classpathref="@{classpath.id}"
 					access="@{access}" excludepackagenames="@{exclude.package.names}" maxmemory="${javadoc.max.memory}"
 					stylesheetfile="${javadoc.stylesheet.file}" splitindex="true" useexternalfile="true">
-				<header><![CDATA[<!-- Begin Google Analytics code --> <script type="text/javascript"> var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www."); document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E")); </script> <script type="text/javascript"> var pageTracker = _gat._getTracker("UA-2728886-3"); pageTracker._setDomainName("none"); pageTracker._setAllowLinker(true); pageTracker._trackPageview(); </script> <!-- End Google Analytics code -->]]></header>
+				<header><![CDATA[<!-- Begin Google Analytics code --> <script type="text/javascript"> var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www."); document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E")); </script> <script type="text/javascript"> var pageTracker = _gat._getTracker("UA-2728886-3"); pageTracker._setDomainName("none"); pageTracker._setAllowLinker(true); pageTracker._trackPageview(); </script> <!-- End Google Analytics code -->]]></header>
 			</javadoc.links>
 			<copy toDir="@{output.dir}/resources">
 				<fileset dir="${javadoc.resources.dir}" erroronmissingdir="false"/>

--- a/spring-build/multi-bundle/common.xml
+++ b/spring-build/multi-bundle/common.xml
@@ -105,7 +105,7 @@
 			<javadoc.links sourcepath="@{input.dir}" destdir="@{output.dir}" classpathref="@{classpath.id}"
 					access="@{access}" excludepackagenames="@{exclude.package.names}" maxmemory="${javadoc.max.memory}"
 					stylesheetfile="${javadoc.stylesheet.file}" splitindex="true"  useexternalfile="true">
-				<header><![CDATA[<!-- Begin Google Analytics code --> <script type="text/javascript"> var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www."); document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E")); </script> <script type="text/javascript"> var pageTracker = _gat._getTracker("UA-2728886-3"); pageTracker._setDomainName("none"); pageTracker._setAllowLinker(true); pageTracker._trackPageview(); </script> <!-- End Google Analytics code -->]]></header>
+				<header><![CDATA[<!-- Begin Google Analytics code --> <script type="text/javascript"> var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www."); document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E")); </script> <script type="text/javascript"> var pageTracker = _gat._getTracker("UA-2728886-3"); pageTracker._setDomainName("none"); pageTracker._setAllowLinker(true); pageTracker._trackPageview(); </script> <!-- End Google Analytics code -->]]></header>
 			</javadoc.links>
 			<copy toDir="@{output.dir}/resources">
 				<fileset dir="${javadoc.resources.dir}" erroronmissingdir="false"/>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://ivyrep.jayasoft.org/ivy-doc.xsl (UnknownHostException) with 1 occurrences migrated to:  
  https://ivyrep.jayasoft.org/ivy-doc.xsl ([https](https://ivyrep.jayasoft.org/ivy-doc.xsl) result UnknownHostException).
* http://www (UnknownHostException) with 2 occurrences migrated to:  
  https://www ([https](https://www) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://incubator.apache.org/ivy/schemas/ivy.xsd with 1 occurrences migrated to:  
  https://incubator.apache.org/ivy/schemas/ivy.xsd ([https](https://incubator.apache.org/ivy/schemas/ivy.xsd) result 301).

# Ignored
These URLs were intentionally ignored.

* http://nwalsh.com/docbook/xsl/template/1.0 with 2 occurrences
* http://nwalsh.com/docbook/xsl/template/1.0/param with 2 occurrences
* http://www.w3.org/1999/XSL/Format with 1 occurrences
* http://www.w3.org/1999/XSL/Transform with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences