### PR TITLE
URL Cleanup

### DIFF
--- a/notice.txt
+++ b/notice.txt
@@ -4,13 +4,13 @@
    ======================================================================
 
    This product includes software developed by
-   the Apache Software Foundation (http://www.apache.org).
+   the Apache Software Foundation (https://www.apache.org).
 
    The end-user documentation included with a redistribution, if any,
    must include the following acknowledgement:
 
      "This product includes software developed by the Spring Build
-      Project (http://www.springframework.org)."
+      Project (https://www.springframework.org)."
 
    Alternately, this acknowledgement may appear in the software itself,
    if and wherever such third-party acknowledgements normally appear.

--- a/org.springframework.build.aws.ant/src/main/resources/mime.types
+++ b/org.springframework.build.aws.ant/src/main/resources/mime.types
@@ -6,7 +6,7 @@
 # Extra types can either be added here or by using an AddType directive
 # in your config files. For more information about Internet media types,
 # please read RFC 2045, 2046, 2047, 2048, and 2077.  The Internet media type
-# registry is at <http://www.iana.org/assignments/media-types/>.
+# registry is at <https://www.iana.org/assignments/media-types/>.
 
 # MIME type			Extensions
 application/activemessage

--- a/spring-build/docbook/styles/html/custom.xsl
+++ b/spring-build/docbook/styles/html/custom.xsl
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				exclude-result-prefixes="xslthl"
 				version='1.0'>
 
@@ -104,7 +104,7 @@
 	<xsl:template name="user.head.content">
 		<xsl:comment>Begin Google Analytics code</xsl:comment>
 		<script type="text/javascript">
-			var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+			var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 			document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 		</script>
 		<script type="text/javascript">

--- a/spring-build/docbook/styles/pdf/custom.xsl
+++ b/spring-build/docbook/styles/pdf/custom.xsl
@@ -16,7 +16,7 @@
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 				xmlns:fo="http://www.w3.org/1999/XSL/Format"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				exclude-result-prefixes="xslthl"
 				version='1.0'>
 				

--- a/spring-build/lib/ivy/jets3t.properties
+++ b/spring-build/lib/ivy/jets3t.properties
@@ -15,7 +15,7 @@
 ## JetS3t Configuration Properties
 
 # A full description of all configuration properties can be found at
-# http://jets3t.s3.amazonaws.com/toolkit/configuration.html
+# https://jets3t.s3.amazonaws.com/toolkit/configuration.html
 
 # Proxy configuration
 httpclient.proxy-autodetect=true


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://xslthl.sf.net (301) with 2 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www (UnknownHostException) with 1 occurrences migrated to:  
  https://www ([https](https://www) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://jets3t.s3.amazonaws.com/toolkit/configuration.html with 1 occurrences migrated to:  
  https://jets3t.s3.amazonaws.com/toolkit/configuration.html ([https](https://jets3t.s3.amazonaws.com/toolkit/configuration.html) result 200).
* [ ] http://www.apache.org with 1 occurrences migrated to:  
  https://www.apache.org ([https](https://www.apache.org) result 200).
* [ ] http://www.springframework.org with 1 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* [ ] http://www.iana.org/assignments/media-types/ with 1 occurrences migrated to:  
  https://www.iana.org/assignments/media-types/ ([https](https://www.iana.org/assignments/media-types/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 2 occurrences